### PR TITLE
Update release procedure

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,6 +35,7 @@ Configure signing in Microsoft partner portal:
 1. Artifacts are prepared under `bin/dist/`:
     1. `bin/dist/legacy/` contains the final artifacts for Windows 7/8/8.1.
     1. `bin/dist/win10/` contains an intermediate driver package for Windows 10.
+    1. `bin/dist/meta/` currently, only holds the shared PDB file.
 1. Upload Windows 10 intermediate driver package (`mullvad-split-tunnel-amd64.cab`) to Microsoft for attestation signing.
 1. Download attestation signed driver for Windows 10.
 
@@ -42,8 +43,8 @@ Configure signing in Microsoft partner portal:
 
 1. In the `mullvadvpn-app-binaries` repository:
     1. Update legacy driver package in `x86_64-pc-windows-msvc/split-tunnel/legacy/`.
-    1. Move `x86_64-pc-windows-msvc/split-tunnel/legacy/mullvad-split-tunnel.pdb` one step out, into `x86_64-pc-windows-msvc/split-tunnel/`. The PDB is shared between the legacy driver and the Windows 10 driver, because they're actually the same binary. Only the appended signature is different.
     1. Extract attestation signed driver and related files into `x86_64-pc-windows-msvc/split-tunnel/win10/`.
+    1. Update driver PDB file in `x86_64-pc-windows-msvc/split-tunnel/meta/`.
     1. Merge file updates into `master`.
 1. In the `mullvadvpn-app` repository:
     1. Update the `mullvadvpn-app-binaries` submodule reference.

--- a/build.bat
+++ b/build.bat
@@ -46,8 +46,12 @@ rmdir /s /q %ROOT%bin\dist
 mkdir %ROOT%bin\dist\legacy
 copy /b %ROOT%bin\x64-Release\mullvad-split-tunnel\* %ROOT%bin\dist\legacy\
 
+mkdir %ROOT%bin\dist\meta
+move %ROOT%bin\dist\legacy\mullvad-split-tunnel\mullvad-split-tunnel.pdb %ROOT%bin\dist\meta\
+
 ::
 :: Build a CAB file for submission to the MS Hardware Dev Center
+:: The co-installer has to be included (?) because it's referenced in the inf file
 ::
 
 mkdir %ROOT%bin\dist\win10


### PR DESCRIPTION
Move PDB so it doesn't appear to belong only to legacy driver.
Simplify release instructions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/win-split-tunnel/13)
<!-- Reviewable:end -->
