### PR TITLE
Add missing cast and cast to unsigned data type

### DIFF
--- a/src/firewall/logging.cpp
+++ b/src/firewall/logging.cpp
@@ -323,11 +323,11 @@ LogActivatedSplittingMode
 
 	NT_ASSERT
 	(
-		static_cast<SIZE_T>(SPLITTING_MODE::MODE_1) == 1
-		&& static_cast<SIZE_T>(SPLITTING_MODE::MODE_9) == 9
+		static_cast<size_t>(SPLITTING_MODE::MODE_1) == 1
+		&& static_cast<size_t>(SPLITTING_MODE::MODE_9) == 9
 	);
 
-	DbgPrint("Activated splitting mode: %d\n", Mode);
+	DbgPrint("Activated splitting mode: %u\n", static_cast<size_t>(Mode));
 }
 
 }; // namespace firewall


### PR DESCRIPTION
As above.

Building with the DbgPrint override would fail b/c missing cast.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/win-split-tunnel/24)
<!-- Reviewable:end -->
