### PR TITLE
Complete IOCTL requests asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Fixed
+Ensure IOCTL requests are always processed on worker thread to prevent client from getting stuck
+  inside DeviceIoControl API call.
 
 ## [1.1.1.0] - 2021-06-04
 ### Fixed

--- a/src/devicecontext.h
+++ b/src/devicecontext.h
@@ -20,7 +20,7 @@ typedef struct tag_ST_DEVICE_CONTEXT
 	DRIVER_STATE_MGMT DriverState;
 
 	// Serialized queue for processing of most IOCTLs.
-	WDFQUEUE IoCtlQueue;
+	WDFQUEUE SerializedRequestQueue;
 
 	ST_IP_ADDRESSES IpAddresses;
 

--- a/src/devicecontext.h
+++ b/src/devicecontext.h
@@ -19,6 +19,9 @@ typedef struct tag_ST_DEVICE_CONTEXT
 {
 	DRIVER_STATE_MGMT DriverState;
 
+	// Parallel queue for processing IOCTLs which use inverted call.
+	WDFQUEUE ParallelRequestQueue;
+
 	// Serialized queue for processing of most IOCTLs.
 	WDFQUEUE SerializedRequestQueue;
 

--- a/src/driverentry.cpp
+++ b/src/driverentry.cpp
@@ -321,7 +321,7 @@ StCreateDevice
 
     context->DriverState.State = ST_DRIVER_STATE_STARTED;
 
-    context->IoCtlQueue = serialQueue;
+    context->SerializedRequestQueue = serialQueue;
 
     WdfControlFinishInitializing(wdfDevice);
 
@@ -402,7 +402,7 @@ StEvtIoDeviceControl
     // Forward to serialized queue.
     //
 
-    const auto status = RaiseDispatchForwardRequest(Request, context->IoCtlQueue);
+    const auto status = RaiseDispatchForwardRequest(Request, context->SerializedRequestQueue);
 
     if (NT_SUCCESS(status))
     {

--- a/testing/proc.cpp
+++ b/testing/proc.cpp
@@ -1,4 +1,5 @@
 #include <vector>
+#include <iterator>
 #include <cstdint>
 #include <windows.h>
 #include <tlhelp32.h>


### PR DESCRIPTION
There's an optimization in `WdfRequestForwardToIoQueue` that makes it sometimes borrow the calling thread. This breaks the async processing we should be getting when forwarding to a secondary queue in `StEvtIoDeviceControl`. So essentially we fix the state so `WdfRequestForwardToIoQueue` is prevented from borrowing the calling thread and is forced to dispatch on a worker thread instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/win-split-tunnel/28)
<!-- Reviewable:end -->
