### PR TITLE
Reset callout action to CONTINUE for apps that are not split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Security
+- For non-excluded DNS traffic, evaluate all appropriate filters within the DNS sublayer when a soft
+  permit has been applied in a higher-priority sublayer.
 
 ## [1.2.0.0] - 2022-01-10
 ### Changed

--- a/src/firewall/callouts.cpp
+++ b/src/firewall/callouts.cpp
@@ -380,10 +380,7 @@ CalloutClassifyBind
 		return;
 	}
 
-	if (ClassifyOut->actionType == FWP_ACTION_NONE)
-	{
-		ClassifyOut->actionType = FWP_ACTION_CONTINUE;
-	}
+	ClassificationReset(ClassifyOut);
 
 	if (!FWPS_IS_METADATA_FIELD_PRESENT(MetaValues, FWPS_METADATA_FIELD_PROCESS_ID))
 	{
@@ -727,10 +724,7 @@ CalloutClassifyConnect
 		return;
 	}
 
-	if (ClassifyOut->actionType == FWP_ACTION_NONE)
-	{
-		ClassifyOut->actionType = FWP_ACTION_CONTINUE;
-	}
+	ClassificationReset(ClassifyOut);
 
 	if (!FWPS_IS_METADATA_FIELD_PRESENT(MetaValues, FWPS_METADATA_FIELD_PROCESS_ID))
 	{
@@ -940,10 +934,7 @@ CalloutPermitSplitApps
 		return;
 	}
 
-	if (ClassifyOut->actionType == FWP_ACTION_NONE)
-	{
-		ClassifyOut->actionType = FWP_ACTION_CONTINUE;
-	}
+	ClassificationReset(ClassifyOut);
 
 	if (!FWPS_IS_METADATA_FIELD_PRESENT(MetaValues, FWPS_METADATA_FIELD_PROCESS_ID))
 	{
@@ -1093,10 +1084,7 @@ CalloutBlockSplitApps
 		return;
 	}
 
-	if (ClassifyOut->actionType == FWP_ACTION_NONE)
-	{
-		ClassifyOut->actionType = FWP_ACTION_CONTINUE;
-	}
+	ClassificationReset(ClassifyOut);
 
 	if (!FWPS_IS_METADATA_FIELD_PRESENT(MetaValues, FWPS_METADATA_FIELD_PROCESS_ID))
 	{


### PR DESCRIPTION
Callouts of the `FWP_ACTION_CALLOUT_UNKNOWN` type [may return](https://docs.microsoft.com/en-us/windows/win32/api/fwpstypes/ns-fwpstypes-fwps_action0) one of the actions `CONTINUE`, `PERMIT`, or `BLOCK`.

In general, we previously didn't initialize the selected action. In most cases the initial value is 0, which seems to the same effect as `CONTINUE` (or perhaps `BLOCK`). But DNS sublayer callouts receive `PERMIT` as the initial value, the outcome of the baseline sublayer (which unconditionally permits DNS). So the initial value appears to be set to the verdict of the sublayer above it. This led to the DNS sublayer decision for non-split apps to be set to `PERMIT`, causing DNS leaks.

Setting the action to `CONTINUE` causes lower (WinFw) filters within the sublayer to be evaluated. This is always what we want to do for apps that are not supposed to be excluded from the tunnel.

The change fixes unintentional DNS leaks but "breaks" DNS resolution when apps are in a blocking state. Previously, split apps could resolve hostnames, but this is no longer possible. This was unintentional, though, as it was caused by `dnscache` leaking DNS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/win-split-tunnel/32)
<!-- Reviewable:end -->
