### PR TITLE
Correct validation of input buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Fixed
+- Fix incomplete validation of input buffers that could result in out-of-bounds reads.
 
 ## [1.2.1.0] - 2022-04-19
 ### Security

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2,6 +2,7 @@
 #include "defs/config.h"
 #include "defs/process.h"
 #include "util.h"
+#include <ntintsafe.h>
 
 bool
 ValidateUserBufferConfiguration
@@ -25,12 +26,26 @@ ValidateUserBufferConfiguration
         return false;
     }
 
-    auto stringBuffer = (UCHAR*)Buffer
-        + sizeof(ST_CONFIGURATION_HEADER)
-        + (sizeof(ST_CONFIGURATION_ENTRY) * header->NumEntries);
+    //
+    // Verify that the entries reside within the buffer
+    //
 
-    if (stringBuffer < (UCHAR*)Buffer
-        || stringBuffer >= bufferEnd)
+    SIZE_T entriesSize = 0;
+
+    if (STATUS_SUCCESS != RtlSIZETMult(sizeof(ST_CONFIGURATION_ENTRY), header->NumEntries, &entriesSize))
+    {
+        return false;
+    }
+
+    void *stringBuffer = nullptr;
+
+    const auto status = RtlULongPtrAdd(
+        (ULONG_PTR)((UCHAR*)Buffer + sizeof(ST_CONFIGURATION_HEADER)),
+        entriesSize,
+        (ULONG_PTR*)&stringBuffer
+    );
+
+    if (STATUS_SUCCESS != status || stringBuffer >= bufferEnd)
     {
         return false;
     }
@@ -77,12 +92,26 @@ ValidateUserBufferProcesses
         return false;
     }
 
-    auto stringBuffer = (UCHAR*)Buffer
-        + sizeof(ST_PROCESS_DISCOVERY_HEADER)
-        + (sizeof(ST_PROCESS_DISCOVERY_ENTRY) * header->NumEntries);
+    //
+    // Verify that the entries reside within the buffer
+    //
 
-    if (stringBuffer < (UCHAR*)Buffer
-        || stringBuffer >= bufferEnd)
+    SIZE_T entriesSize = 0;
+
+    if (STATUS_SUCCESS != RtlSIZETMult(sizeof(ST_PROCESS_DISCOVERY_ENTRY), header->NumEntries, &entriesSize))
+    {
+        return false;
+    }
+
+    void *stringBuffer = nullptr;
+
+    const auto status = RtlULongPtrAdd(
+        (ULONG_PTR)((UCHAR*)Buffer + sizeof(ST_PROCESS_DISCOVERY_HEADER)),
+        entriesSize,
+        (ULONG_PTR*)&stringBuffer
+    );
+
+    if (STATUS_SUCCESS != status || stringBuffer >= bufferEnd)
     {
         return false;
     }


### PR DESCRIPTION
If `header->NumEntries` is very large, an overflow occurs while obtaining a pointer to the end of the entries (`stringBuffer`). If that pointer is still inside the input buffer, then the validation functions proceed to check strings outside of the buffer.

The PR fixes this by ensuring that `sizeof(ST_CONFIGURATION_ENTRY) * header->NumEntries` does not overflow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/win-split-tunnel/34)
<!-- Reviewable:end -->
