### PR TITLE
Update build tools and remove deprecated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,15 @@ Main features:
 
 # Development environment
 
+Any recent version of Visual Studio, the WDK, and Windows SDK should work.
+
 The code and project file is known to work with the following combination of software:
 
-- Visual Studio 2019 (MSVC toolset >= v14.26)
-- WDK v10.0.18362.1
+- Visual Studio 2022
+- WDK v10.0.22621.382
+- Windows SDK v10.0.22621.0
+
+It will only build on Windows 10, version 2004 or later.
 
 # Architecture
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@ Ensure the following software is installed:
 
 1. `Visual Studio 2019` or later.
 1. `Windows Driver Kit (WDK)` version `10.0.18362.1` or later.
+1. `Windows 10, version 2004` or later.
 
 Configure signing locally:
 

--- a/src/containers/procregistry.cpp
+++ b/src/containers/procregistry.cpp
@@ -49,7 +49,7 @@ TreeAllocateRoutineNonPaged
 {
 	UNREFERENCED_PARAMETER(Table);
 
-	return ExAllocatePoolWithTag(NonPagedPool, ByteSize, ST_POOL_TAG);
+	return ExAllocatePoolUninitialized(NonPagedPool, ByteSize, ST_POOL_TAG);
 }
 
 PVOID
@@ -61,7 +61,7 @@ TreeAllocateRoutinePaged
 {
 	UNREFERENCED_PARAMETER(Table);
 
-	return ExAllocatePoolWithTag(PagedPool, ByteSize, ST_POOL_TAG);
+	return ExAllocatePoolUninitialized(PagedPool, ByteSize, ST_POOL_TAG);
 }
 
 VOID
@@ -144,7 +144,7 @@ Initialize
 	const auto poolType = (Pageable == ST_PAGEABLE::YES) ? PagedPool : NonPagedPool;
 
 	*Context = (CONTEXT*)
-		ExAllocatePoolWithTag(poolType, sizeof(CONTEXT), ST_POOL_TAG);
+		ExAllocatePoolUninitialized(poolType, sizeof(CONTEXT), ST_POOL_TAG);
 
 	if (*Context == NULL)
 	{

--- a/src/containers/registeredimage.cpp
+++ b/src/containers/registeredimage.cpp
@@ -90,7 +90,7 @@ AddEntryInner
 	const auto poolType = (Context->Pageable == ST_PAGEABLE::YES) ? PagedPool : NonPagedPool;
 
     auto record = (REGISTERED_IMAGE_ENTRY*)
-		ExAllocatePoolWithTag(poolType, allocationSize, ST_POOL_TAG);
+		ExAllocatePoolUninitialized(poolType, allocationSize, ST_POOL_TAG);
 
     if (record == NULL)
     {
@@ -141,7 +141,7 @@ Initialize
 {
 	const auto poolType = (Pageable == ST_PAGEABLE::YES) ? PagedPool : NonPagedPool;
 
-	*Context = (CONTEXT*)ExAllocatePoolWithTag(poolType, sizeof(CONTEXT), ST_POOL_TAG);
+	*Context = (CONTEXT*)ExAllocatePoolUninitialized(poolType, sizeof(CONTEXT), ST_POOL_TAG);
 
 	if (*Context == NULL)
 	{

--- a/src/eventing/builder.cpp
+++ b/src/eventing/builder.cpp
@@ -21,7 +21,7 @@ BuildSplittingEvent
 	auto eventSize = FIELD_OFFSET(ST_SPLITTING_EVENT, ImageName) + ImageName->Length;
 	auto allocationSize = headerSize + eventSize;
 
-	auto buffer = ExAllocatePoolWithTag(NonPagedPool, allocationSize, ST_POOL_TAG);
+	auto buffer = ExAllocatePoolUninitialized(NonPagedPool, allocationSize, ST_POOL_TAG);
 
 	if (buffer == NULL)
 	{
@@ -60,7 +60,7 @@ BuildSplittingErrorEvent
 	auto eventSize = FIELD_OFFSET(ST_SPLITTING_ERROR_EVENT, ImageName) + ImageName->Length;
 	auto allocationSize = headerSize + eventSize;
 
-	auto buffer = ExAllocatePoolWithTag(NonPagedPool, allocationSize, ST_POOL_TAG);
+	auto buffer = ExAllocatePoolUninitialized(NonPagedPool, allocationSize, ST_POOL_TAG);
 
 	if (buffer == NULL)
 	{
@@ -91,7 +91,7 @@ WrapEvent
 	size_t BufferSize
 )
 {
-	auto evt = (RAW_EVENT*)ExAllocatePoolWithTag(NonPagedPool, sizeof(RAW_EVENT), ST_POOL_TAG);
+	auto evt = (RAW_EVENT*)ExAllocatePoolUninitialized(NonPagedPool, sizeof(RAW_EVENT), ST_POOL_TAG);
 
 	if (evt == NULL)
 	{
@@ -203,7 +203,7 @@ BuildErrorMessageEvent
 	auto eventSize = FIELD_OFFSET(ST_ERROR_MESSAGE_EVENT, ErrorMessage) + ErrorMessage->Length;
 	auto allocationSize = headerSize + eventSize;
 
-	auto buffer = ExAllocatePoolWithTag(NonPagedPool, allocationSize, ST_POOL_TAG);
+	auto buffer = ExAllocatePoolUninitialized(NonPagedPool, allocationSize, ST_POOL_TAG);
 
 	if (buffer == NULL)
 	{

--- a/src/eventing/eventing.cpp
+++ b/src/eventing/eventing.cpp
@@ -71,7 +71,7 @@ Initialize
 {
    *Context = NULL;
 
-    auto context = (CONTEXT*)ExAllocatePoolWithTag(NonPagedPool, sizeof(CONTEXT), ST_POOL_TAG);
+    auto context = (CONTEXT*)ExAllocatePoolUninitialized(NonPagedPool, sizeof(CONTEXT), ST_POOL_TAG);
 
     if (NULL == context)
     {

--- a/src/firewall/appfilters.cpp
+++ b/src/firewall/appfilters.cpp
@@ -104,7 +104,7 @@ PushTransactionEvent
 	BLOCK_CONNECTIONS_ENTRY *Target
 )
 {
-	auto evt = (TRANSACTION_EVENT*)ExAllocatePoolWithTag(NonPagedPool, sizeof(TRANSACTION_EVENT), ST_POOL_TAG);
+	auto evt = (TRANSACTION_EVENT*)ExAllocatePoolUninitialized(NonPagedPool, sizeof(TRANSACTION_EVENT), ST_POOL_TAG);
 
 	if (evt == NULL)
 	{
@@ -175,7 +175,7 @@ TransactionRemovedEntry
 )
 {
 	auto evt = (TRANSACTION_EVENT_ADD_ENTRY*)
-		ExAllocatePoolWithTag(NonPagedPool, sizeof(TRANSACTION_EVENT_ADD_ENTRY), ST_POOL_TAG);
+		ExAllocatePoolUninitialized(NonPagedPool, sizeof(TRANSACTION_EVENT_ADD_ENTRY), ST_POOL_TAG);
 
 	if (evt == NULL)
 	{
@@ -201,7 +201,7 @@ TransactionSwappedLists
 )
 {
 	auto evt = (TRANSACTION_EVENT_SWAP_LISTS*)
-		ExAllocatePoolWithTag(NonPagedPool, sizeof(TRANSACTION_EVENT_SWAP_LISTS), ST_POOL_TAG);
+		ExAllocatePoolUninitialized(NonPagedPool, sizeof(TRANSACTION_EVENT_SWAP_LISTS), ST_POOL_TAG);
 
 	if (evt == NULL)
 	{
@@ -246,7 +246,7 @@ CustomGetAppIdFromFileName
 	auto allocationSize = offsetStringBuffer + copiedStringLength;
 
 	auto blob = (FWP_BYTE_BLOB*)
-		ExAllocatePoolWithTag(PagedPool, allocationSize, ST_POOL_TAG);
+		ExAllocatePoolUninitialized(PagedPool, allocationSize, ST_POOL_TAG);
 
 	if (blob == NULL)
 	{
@@ -519,7 +519,7 @@ AddBlockFiltersCreateEntryTx
 	auto allocationSize = offsetStringBuffer + ImageName->Length;
 
 	auto entry = (BLOCK_CONNECTIONS_ENTRY*)
-		ExAllocatePoolWithTag(PagedPool, allocationSize, ST_POOL_TAG);
+		ExAllocatePoolUninitialized(PagedPool, allocationSize, ST_POOL_TAG);
 
 	if (entry == NULL)
 	{
@@ -695,7 +695,7 @@ Initialize
 )
 {
 	auto context = (APP_FILTERS_CONTEXT*)
-		ExAllocatePoolWithTag(PagedPool, sizeof(APP_FILTERS_CONTEXT), ST_POOL_TAG);
+		ExAllocatePoolUninitialized(PagedPool, sizeof(APP_FILTERS_CONTEXT), ST_POOL_TAG);
 
 	if (context == NULL)
 	{

--- a/src/firewall/firewall.cpp
+++ b/src/firewall/firewall.cpp
@@ -973,7 +973,7 @@ Initialize
 	eventing::CONTEXT *Eventing
 )
 {
-	auto context = (CONTEXT*)ExAllocatePoolWithTag(NonPagedPool, sizeof(CONTEXT), ST_POOL_TAG);
+	auto context = (CONTEXT*)ExAllocatePoolUninitialized(NonPagedPool, sizeof(CONTEXT), ST_POOL_TAG);
 
 	if (context == NULL)
 	{

--- a/src/firewall/pending.cpp
+++ b/src/firewall/pending.cpp
@@ -333,11 +333,11 @@ Initialize
 	procbroker::CONTEXT *ProcessEventBroker
 )
 {
-	auto context = (CONTEXT*)ExAllocatePoolWithTag(NonPagedPool, sizeof(CONTEXT), ST_POOL_TAG);
+	auto context = (CONTEXT*)ExAllocatePoolUninitialized(NonPagedPool, sizeof(CONTEXT), ST_POOL_TAG);
 
 	if (context == NULL)
 	{
-        DbgPrint("ExAllocatePoolWithTag() failed\n");
+        DbgPrint("ExAllocatePoolUninitialized() failed\n");
 
 		return STATUS_INSUFFICIENT_RESOURCES;
 	}
@@ -429,11 +429,11 @@ PendRequest
     );
 
     auto record = (PENDED_CLASSIFICATION*)
-        ExAllocatePoolWithTag(NonPagedPool, sizeof(PENDED_CLASSIFICATION), ST_POOL_TAG);
+        ExAllocatePoolUninitialized(NonPagedPool, sizeof(PENDED_CLASSIFICATION), ST_POOL_TAG);
 
     if (record == NULL)
     {
-        DbgPrint("ExAllocatePoolWithTag() failed\n");
+        DbgPrint("ExAllocatePoolUninitialized() failed\n");
 
         return STATUS_INSUFFICIENT_RESOURCES;
     }

--- a/src/mullvad-split-tunnel.sln
+++ b/src/mullvad-split-tunnel.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29609.76
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32825.248
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mullvad-split-tunnel", "mullvad-split-tunnel.vcxproj", "{5B2A6B2C-D052-43DA-8181-EACB5F93E5A9}"
 EndProject

--- a/src/mullvad-split-tunnel.vcxproj
+++ b/src/mullvad-split-tunnel.vcxproj
@@ -134,7 +134,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
       <PreprocessorDefinitions>_ARM64_;ARM64;_USE_DECLSPECS_FOR_SAL=1;STD_CALL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <WppEnabled>true</WppEnabled>
       <WppScanConfigurationData>trace.h</WppScanConfigurationData>
     </ClCompile>
@@ -158,7 +158,7 @@
       <AdditionalOptions>/INTEGRITYCHECK %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <ClCompile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <WppEnabled>true</WppEnabled>
       <WppScanConfigurationData>trace.h</WppScanConfigurationData>
     </ClCompile>

--- a/src/procbroker/procbroker.cpp
+++ b/src/procbroker/procbroker.cpp
@@ -14,7 +14,7 @@ Initialize
 	CONTEXT **Context
 )
 {
-    auto context = (CONTEXT*)ExAllocatePoolWithTag(PagedPool, sizeof(CONTEXT), ST_POOL_TAG);
+    auto context = (CONTEXT*)ExAllocatePoolUninitialized(PagedPool, sizeof(CONTEXT), ST_POOL_TAG);
 
     if (NULL == context)
     {
@@ -71,7 +71,7 @@ Subscribe
     void *ClientContext
 )
 {
-    auto sub = (SUBSCRIPTION*)ExAllocatePoolWithTag(PagedPool, sizeof(SUBSCRIPTION), ST_POOL_TAG);
+    auto sub = (SUBSCRIPTION*)ExAllocatePoolUninitialized(PagedPool, sizeof(SUBSCRIPTION), ST_POOL_TAG);
 
     if (NULL == sub)
     {

--- a/src/procmgmt/procmgmt.cpp
+++ b/src/procmgmt/procmgmt.cpp
@@ -513,7 +513,7 @@ Initialize
     void *CallbackContext
 )
 {
-    auto context = (CONTEXT*)ExAllocatePoolWithTag(NonPagedPool, sizeof(CONTEXT), ST_POOL_TAG);
+    auto context = (CONTEXT*)ExAllocatePoolUninitialized(NonPagedPool, sizeof(CONTEXT), ST_POOL_TAG);
 
     if (NULL == context)
     {

--- a/src/procmon/procmon.cpp
+++ b/src/procmon/procmon.cpp
@@ -66,7 +66,7 @@ SystemProcessEvent
 
         auto allocationSize = offsetStringBuffer + imageName->Length;
 
-        record = (PROCESS_EVENT *)ExAllocatePoolWithTag(PagedPool, allocationSize, ST_POOL_TAG);
+        record = (PROCESS_EVENT *)ExAllocatePoolUninitialized(PagedPool, allocationSize, ST_POOL_TAG);
 
         if (record == NULL)
         {
@@ -101,7 +101,7 @@ SystemProcessEvent
         // Process is departing.
         //
 
-        record = (PROCESS_EVENT *)ExAllocatePoolWithTag(PagedPool, sizeof(PROCESS_EVENT), ST_POOL_TAG);
+        record = (PROCESS_EVENT *)ExAllocatePoolUninitialized(PagedPool, sizeof(PROCESS_EVENT), ST_POOL_TAG);
 
         if (record == NULL)
         {
@@ -198,7 +198,7 @@ Initialize
 
     bool notifyRoutineRegistered = false;
 
-    auto context = (CONTEXT*)ExAllocatePoolWithTag(NonPagedPool, sizeof(CONTEXT), ST_POOL_TAG);
+    auto context = (CONTEXT*)ExAllocatePoolUninitialized(NonPagedPool, sizeof(CONTEXT), ST_POOL_TAG);
 
     if (NULL == context)
     {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -119,7 +119,7 @@ GetDevicePathImageName
 	// Allocate name buffer.
 	//
 
-	*ImageName = (UNICODE_STRING*)ExAllocatePoolWithTag(PagedPool, bufferLength, ST_POOL_TAG);
+	*ImageName = (UNICODE_STRING*)ExAllocatePoolUninitialized(PagedPool, bufferLength, ST_POOL_TAG);
 
 	if (NULL == *ImageName)
 	{
@@ -241,7 +241,7 @@ AllocateCopyDowncaseString
 
 	const auto poolType = (Pageable == ST_PAGEABLE::YES) ? PagedPool : NonPagedPool;
 
-	auto finalBuffer = (PWCH)ExAllocatePoolWithTag(poolType, lower.Length, ST_POOL_TAG);
+	auto finalBuffer = (PWCH)ExAllocatePoolUninitialized(poolType, lower.Length, ST_POOL_TAG);
 
 	if (finalBuffer == NULL)
 	{
@@ -293,7 +293,7 @@ DuplicateString
 {
 	const auto poolType = (Pageable == ST_PAGEABLE::YES) ? PagedPool : NonPagedPool;
 
-	auto buffer = (PWCH)ExAllocatePoolWithTag(poolType, Src->Length, ST_POOL_TAG);
+	auto buffer = (PWCH)ExAllocatePoolUninitialized(poolType, Src->Length, ST_POOL_TAG);
 
 	if (NULL == buffer)
 	{


### PR DESCRIPTION
* Fix deprecation warnings for `ExAllocatePoolWithTag`. `ExAllocatePoolUninitialized` was used instead since `ExAllocatePool2` only targets Windows 10 version 2004 or higher.
* Bump the current VS version to 2022. The code should still build on VS 2019, so that's still referred to as the minimum in `RELEASE.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/win-split-tunnel/35)
<!-- Reviewable:end -->
